### PR TITLE
Fix for latest versions of mpv

### DIFF
--- a/index.cc
+++ b/index.cc
@@ -39,6 +39,7 @@ static const std::unordered_map<std::string, void*> GL_CALLBACKS = {
   GLCB(BindTexture),
   GLCB(BlendFuncSeparate),
   GLCB(BufferData),
+  GLCB(BufferSubData),
   GLCB(Clear),
   GLCB(ClearColor),
   GLCB(CompileShader),


### PR DESCRIPTION
Without this change plugin can not be started and there are messages in the console:
```
FIXME: missed GL function BufferSubData
failed to initialize mpv GL context
```
